### PR TITLE
Feat: Add Gamma market import command

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ CLI examples:
 ```bash
 bun run startcli -- markets list-markets
 bun run startcli -- markets get <conditionId>
+bun run startcli -- markets import <conditionId>
 bun run startcli -- watchlist list
 bun run startcli -- watchlist add <wallet> "high signal trader" 1.25
 bun run startcli -- watchlist remove <wallet>

--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "polymarket-bot",

--- a/src/cli/__test__/market.test.ts
+++ b/src/cli/__test__/market.test.ts
@@ -6,8 +6,14 @@ import { beforeEach, describe, expect, it } from 'vitest';
 
 import { App, initializeApp } from '~/app.js';
 import { markets } from '~/cli/commands/market.js';
-import type { GammaMarketApiClient } from '~/gamma/market/market.js';
+import type {
+  GammaMarket,
+  GammaMarketApiClient,
+} from '~/gamma/market/market.js';
 import type { Storage } from '~/storage/index.js';
+import type { MarketStorage } from '~/storage/market.js';
+
+type UpsertMarketRequest = Parameters<MarketStorage['upsertMarket']>[0];
 
 const testMarket = {
   condition_id: 'condition-123',
@@ -22,6 +28,17 @@ const testMarket = {
   volume_usd: new Decimal('1234.56'),
   created_at: new Date('2026-04-01T12:00:00.000Z'),
   updated_at: new Date('2026-04-02T12:00:00.000Z'),
+};
+const testGammaMarket: GammaMarket = {
+  id: 'gamma-market-123',
+  conditionId: 'condition-123',
+  question: 'Will this command work?',
+  description: null,
+  outcomes: '["Yes","No"]',
+  endDate: '2026-04-10T12:00:00.000Z',
+  volume: '1234.56',
+  active: true,
+  closed: false,
 };
 const storage = td.object<Storage>();
 const logger = td.object<Logger>();
@@ -93,6 +110,67 @@ describe('markets command', () => {
   it('requires a condition ID argument', async () => {
     await expect(
       createCommandUnderTest().parseAsync(['get'], {
+        from: 'user',
+      }),
+    ).rejects.toMatchObject({
+      code: 'commander.missingArgument',
+    });
+  });
+
+  it('imports a market from Gamma by condition ID', async () => {
+    let requestedConditionId: string | undefined;
+    let request: UpsertMarketRequest | undefined;
+
+    td.when(gammaApiClient.getMarketById(td.matchers.isA(String))).thenDo(
+      (conditionId: string) => {
+        requestedConditionId = conditionId;
+        return Promise.resolve(testGammaMarket);
+      },
+    );
+    td.when(storage.market.upsertMarket(td.matchers.anything())).thenDo(
+      (input: UpsertMarketRequest) => {
+        request = input;
+        return Promise.resolve(testMarket);
+      },
+    );
+
+    await createCommandUnderTest().parseAsync(['import', 'condition-123'], {
+      from: 'user',
+    });
+
+    expect(requestedConditionId).toBe('condition-123');
+    expect(request).toEqual({
+      condition_id: 'condition-123',
+      question: 'Will this command work?',
+      category: null,
+      outcome_a: 'Yes',
+      outcome_b: 'No',
+      status: 'ACTIVE',
+      outcome: null,
+      closes_at: new Date('2026-04-10T12:00:00.000Z'),
+      resolved_at: null,
+      volume_usd: '1234.56',
+    });
+    td.verify(
+      logger.info({ result: testMarket }, 'Market imported successfully'),
+    );
+  });
+
+  it('fails when Gamma does not return the market to import', async () => {
+    td.when(gammaApiClient.getMarketById('missing-market')).thenResolve(null);
+
+    await expect(
+      createCommandUnderTest().parseAsync(['import', 'missing-market'], {
+        from: 'user',
+      }),
+    ).rejects.toThrow(
+      'Market with condition ID "missing-market" was not found in Gamma',
+    );
+  });
+
+  it('requires a condition ID argument for import', async () => {
+    await expect(
+      createCommandUnderTest().parseAsync(['import'], {
         from: 'user',
       }),
     ).rejects.toMatchObject({

--- a/src/cli/commands/market.ts
+++ b/src/cli/commands/market.ts
@@ -2,12 +2,42 @@ import { createCommand, createOption } from 'commander';
 import { z } from 'zod';
 
 import { App, instruction } from '~/app.js';
+import type { GammaMarket } from '~/gamma/market/market.js';
+import type { CreateMarketInput } from '~/storage/market.js';
 
 const listMarketSchema = z.object({
   count: z.number().int().positive().min(1),
   offset: z.number().int().nonnegative(),
   asc: z.boolean(),
 });
+const marketOutcomesSchema = z.tuple([z.string(), z.string()]);
+
+function parseMarketOutcomes(outcomes: string) {
+  const parsedJson = JSON.parse(outcomes);
+  const parsedOutcomes = marketOutcomesSchema.parse(parsedJson);
+
+  return {
+    outcome_a: parsedOutcomes[0],
+    outcome_b: parsedOutcomes[1],
+  };
+}
+
+function mapGammaMarketToCreateMarketInput(market: GammaMarket) {
+  const { outcome_a, outcome_b } = parseMarketOutcomes(market.outcomes);
+
+  return {
+    condition_id: market.conditionId,
+    question: market.question,
+    category: null,
+    outcome_a,
+    outcome_b,
+    status: market.closed ? 'CLOSED' : market.active ? 'ACTIVE' : 'CLOSED',
+    outcome: null,
+    closes_at: new Date(market.endDate),
+    resolved_at: null,
+    volume_usd: market.volume,
+  } satisfies CreateMarketInput;
+}
 
 const listMarkets = (app: App) =>
   createCommand('list-markets')
@@ -70,11 +100,38 @@ const getMarket = (app: App) =>
       app.logger.info({ result }, 'Market fetched successfully');
     });
 
+const importMarket = (app: App) =>
+  createCommand('import')
+    .description('Import a market from Gamma by condition ID')
+    .argument('<conditionId>', 'Market condition ID')
+    .action(async (conditionId: string) => {
+      const result = await app
+        .execute(({ gammaApiClient, storage }) =>
+          instruction(async () => {
+            const market = await gammaApiClient.getMarketById(conditionId);
+
+            if (!market) {
+              throw new Error(
+                `Market with condition ID "${conditionId}" was not found in Gamma`,
+              );
+            }
+
+            return storage.market.upsertMarket(
+              mapGammaMarketToCreateMarketInput(market),
+            );
+          }),
+        )
+        .once();
+
+      app.logger.info({ result }, 'Market imported successfully');
+    });
+
 export const markets = (app: App) => {
   const parentCommand = createCommand('markets').description(
     'Commands related to markets',
   );
   parentCommand.addCommand(getMarket(app));
+  parentCommand.addCommand(importMarket(app));
   parentCommand.addCommand(listMarkets(app));
   parentCommand.addCommand(listResolvedMarkets(app));
   return parentCommand;

--- a/src/gamma/__test__/market.test.ts
+++ b/src/gamma/__test__/market.test.ts
@@ -86,3 +86,88 @@ describe('scrapeResolvedMarkets', () => {
     );
   });
 });
+
+describe('getMarketById', () => {
+  it('should fetch a market by condition ID', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => [
+        {
+          id: '1',
+          question: 'Will it rain tomorrow?',
+          description: null,
+          conditionId: 'condition-123',
+          outcomes: '["Yes","No"]',
+          endDate: '2026-04-10T12:00:00.000Z',
+          volume: '1234.56',
+          active: true,
+          closed: false,
+        },
+      ],
+    } as Response;
+    td.when(global.fetch(td.matchers.anything())).thenResolve(mockResponse);
+
+    const market = await gammaApiClient.getMarketById('condition-123');
+
+    td.verify(
+      global.fetch(
+        'https://gamma-api.polymarket.com/markets?condition_ids=condition-123',
+      ),
+      { times: 1 },
+    );
+    expect(market).toEqual({
+      id: '1',
+      question: 'Will it rain tomorrow?',
+      description: null,
+      conditionId: 'condition-123',
+      outcomes: '["Yes","No"]',
+      endDate: '2026-04-10T12:00:00.000Z',
+      volume: '1234.56',
+      active: true,
+      closed: false,
+    });
+    td.verify(
+      logger.error(
+        td.matchers.anything(),
+        'Failed to fetch market by condition ID',
+      ),
+      { times: 0 },
+    );
+  });
+
+  it('should return null when Gamma returns no matching market', async () => {
+    const mockResponse = {
+      ok: true,
+      status: 200,
+      json: async () => [],
+    } as Response;
+    td.when(global.fetch(td.matchers.anything())).thenResolve(mockResponse);
+
+    await expect(
+      gammaApiClient.getMarketById('condition-123'),
+    ).resolves.toBeNull();
+  });
+
+  it('should log an error if fetching a market fails', async () => {
+    const mockResponse = {
+      ok: false,
+      status: 500,
+      json: async () => ({}),
+    } as Response;
+    td.when(global.fetch(td.matchers.anything())).thenResolve(mockResponse);
+
+    await expect(gammaApiClient.getMarketById('condition-123')).rejects.toThrow(
+      'Failed to fetch market by condition ID',
+    );
+    td.verify(
+      logger.error(
+        {
+          response: mockResponse,
+        },
+        'Failed to fetch market by condition ID',
+      ),
+      { times: 1 },
+    );
+  });
+});

--- a/src/gamma/market/market.ts
+++ b/src/gamma/market/market.ts
@@ -7,19 +7,50 @@ type Dependencies = {
 };
 
 export type GammaMarketApiClient = {
+  getMarketById: (conditionId: string) => Promise<GammaMarket | null>;
   scrapeResolvedMarkets: (data: {
     count: number;
     offset: number;
     asc: boolean;
-  }) => Promise<z.infer<typeof MarketApiSchema>[]>;
+  }) => Promise<ResolvedGammaMarket[]>;
 };
 
-const MarketApiSchema = z.object({
+const ResolvedMarketApiSchema = z.object({
   id: z.string(),
   question: z.string(),
   description: z.string().nullable(),
   closed: z.boolean(),
 });
+
+const MarketApiSchema = ResolvedMarketApiSchema.extend({
+  conditionId: z.string(),
+  outcomes: z.string(),
+  endDate: z.string(),
+  volume: z.string(),
+  active: z.boolean(),
+});
+
+export type ResolvedGammaMarket = z.infer<typeof ResolvedMarketApiSchema>;
+export type GammaMarket = z.infer<typeof MarketApiSchema>;
+
+function getMarketById(
+  deps: Dependencies,
+): GammaMarketApiClient['getMarketById'] {
+  return async function (conditionId) {
+    const { logger } = deps;
+    const response = await fetch(
+      `https://gamma-api.polymarket.com/markets?condition_ids=${conditionId}`,
+    );
+    const markets = await handleResponse(
+      response,
+      MarketApiSchema.array(),
+      logger,
+      'Failed to fetch market by condition ID',
+    );
+
+    return markets[0] ?? null;
+  };
+}
 
 function scrapeResolvedMarkets(
   deps: Dependencies,
@@ -32,7 +63,7 @@ function scrapeResolvedMarkets(
     );
     const markets = await handleResponse(
       response,
-      MarketApiSchema.array(),
+      ResolvedMarketApiSchema.array(),
       logger,
       'Failed to fetch resolved markets',
     );
@@ -42,6 +73,7 @@ function scrapeResolvedMarkets(
 
 export const createGammaMarketApiClient = (deps: Dependencies) => {
   return {
+    getMarketById: getMarketById(deps),
     scrapeResolvedMarkets: scrapeResolvedMarkets(deps),
   };
 };

--- a/src/storage/__test__/market.test.ts
+++ b/src/storage/__test__/market.test.ts
@@ -1,0 +1,153 @@
+import { Decimal } from 'decimal.js';
+import { describe, expect, it } from 'vitest';
+
+import { createMarketStorage } from '~/storage/market.js';
+
+const marketRow = {
+  condition_id: 'condition-123',
+  question: 'Will this import work?',
+  category: null,
+  outcome_a: 'Yes',
+  outcome_b: 'No',
+  status: 'ACTIVE' as const,
+  outcome: null,
+  closes_at: new Date('2026-04-10T12:00:00.000Z'),
+  resolved_at: null,
+  volume_usd: '1234.56',
+  created_at: new Date('2026-04-01T12:00:00.000Z'),
+  updated_at: new Date('2026-04-02T12:00:00.000Z'),
+};
+
+describe('createMarketStorage', () => {
+  it('upserts a market by condition_id', async () => {
+    const recorded: {
+      conflictColumn?: string;
+      table?: string;
+      updateSet?: {
+        question: string;
+        category: string | null;
+        outcome_a: string;
+        outcome_b: string;
+        status: 'ACTIVE' | 'CLOSED' | 'RESOLVED';
+        outcome: number | null;
+        closes_at: Date;
+        resolved_at: Date | null;
+        volume_usd: string;
+        updated_at: Date;
+      };
+      values?: {
+        condition_id: string;
+        question: string;
+        category: string | null;
+        outcome_a: string;
+        outcome_b: string;
+        status: 'ACTIVE' | 'CLOSED' | 'RESOLVED';
+        outcome: number | null;
+        closes_at: Date;
+        resolved_at: Date | null;
+        volume_usd: string;
+        updated_at: Date;
+      };
+    } = {};
+
+    const conflictBuilder = {
+      column: (column: string) => {
+        recorded.conflictColumn = column;
+        return {
+          doUpdateSet: (updateSet: {
+            question: string;
+            category: string | null;
+            outcome_a: string;
+            outcome_b: string;
+            status: 'ACTIVE' | 'CLOSED' | 'RESOLVED';
+            outcome: number | null;
+            closes_at: Date;
+            resolved_at: Date | null;
+            volume_usd: string;
+            updated_at: Date;
+          }) => {
+            recorded.updateSet = updateSet;
+            return updateSet;
+          },
+        };
+      },
+    };
+
+    const insertBuilder = {
+      values: (values: {
+        condition_id: string;
+        question: string;
+        category: string | null;
+        outcome_a: string;
+        outcome_b: string;
+        status: 'ACTIVE' | 'CLOSED' | 'RESOLVED';
+        outcome: number | null;
+        closes_at: Date;
+        resolved_at: Date | null;
+        volume_usd: string;
+        updated_at: Date;
+      }) => {
+        recorded.values = values;
+        return insertBuilder;
+      },
+      onConflict: (callback: (builder: typeof conflictBuilder) => unknown) => {
+        callback(conflictBuilder);
+        return insertBuilder;
+      },
+      returningAll: () => insertBuilder,
+      executeTakeFirstOrThrow: async () => marketRow,
+    };
+
+    const db = {
+      insertInto: (table: string) => {
+        recorded.table = table;
+        return insertBuilder;
+      },
+    };
+
+    const result = await createMarketStorage(db as never).upsertMarket({
+      condition_id: 'condition-123',
+      question: 'Will this import work?',
+      category: null,
+      outcome_a: 'Yes',
+      outcome_b: 'No',
+      status: 'ACTIVE',
+      outcome: null,
+      closes_at: new Date('2026-04-10T12:00:00.000Z'),
+      resolved_at: null,
+      volume_usd: '1234.56',
+    });
+
+    expect(recorded.table).toBe('markets');
+    expect(recorded.values).toEqual({
+      condition_id: 'condition-123',
+      question: 'Will this import work?',
+      category: null,
+      outcome_a: 'Yes',
+      outcome_b: 'No',
+      status: 'ACTIVE',
+      outcome: null,
+      closes_at: new Date('2026-04-10T12:00:00.000Z'),
+      resolved_at: null,
+      volume_usd: '1234.56',
+      updated_at: expect.any(Date),
+    });
+    expect(recorded.conflictColumn).toBe('condition_id');
+    expect(recorded.updateSet).toEqual({
+      question: 'Will this import work?',
+      category: null,
+      outcome_a: 'Yes',
+      outcome_b: 'No',
+      status: 'ACTIVE',
+      outcome: null,
+      closes_at: new Date('2026-04-10T12:00:00.000Z'),
+      resolved_at: null,
+      volume_usd: '1234.56',
+      updated_at: expect.any(Date),
+    });
+    expect(result).toEqual({
+      ...marketRow,
+      volume_usd: new Decimal('1234.56'),
+    });
+  });
+});

--- a/src/storage/market.ts
+++ b/src/storage/market.ts
@@ -4,6 +4,20 @@ import { KyselyDB } from './types.js';
 export type MarketStorage = {
   listMarkets: () => Promise<Models['Market'][]>;
   getMarketById: (id: string) => Promise<Models['Market'] | null>;
+  upsertMarket: (input: CreateMarketInput) => Promise<Models['Market']>;
+};
+
+export type CreateMarketInput = {
+  condition_id: string;
+  question: string;
+  category: string | null;
+  outcome_a: string;
+  outcome_b: string;
+  status: Models['Market']['status'];
+  outcome: number | null;
+  closes_at: Date;
+  resolved_at: Date | null;
+  volume_usd: string;
 };
 
 function listMarkets(db: KyselyDB): MarketStorage['listMarkets'] {
@@ -27,9 +41,41 @@ function getMarketById(db: KyselyDB): MarketStorage['getMarketById'] {
   };
 }
 
+function upsertMarket(db: KyselyDB): MarketStorage['upsertMarket'] {
+  return async function (input) {
+    const updated_at = new Date();
+
+    const result = await db
+      .insertInto('markets')
+      .values({
+        ...input,
+        updated_at,
+      })
+      .onConflict((conflict) =>
+        conflict.column('condition_id').doUpdateSet({
+          question: input.question,
+          category: input.category,
+          outcome_a: input.outcome_a,
+          outcome_b: input.outcome_b,
+          status: input.status,
+          outcome: input.outcome,
+          closes_at: input.closes_at,
+          resolved_at: input.resolved_at,
+          volume_usd: input.volume_usd,
+          updated_at,
+        }),
+      )
+      .returningAll()
+      .executeTakeFirstOrThrow();
+
+    return Models['Market'].parse(result);
+  };
+}
+
 export function createMarketStorage(db: KyselyDB): MarketStorage {
   return {
     getMarketById: getMarketById(db),
     listMarkets: listMarkets(db),
+    upsertMarket: upsertMarket(db),
   };
 }


### PR DESCRIPTION
# Summary
- Add a tightly scoped market import flow that fetches a single market from Gamma and upserts it into local storage.
- This makes the existing local market commands usable end-to-end and adds coverage for the Gamma client, storage upsert, and CLI behavior.