### PR TITLE
Feat/tx runner

### DIFF
--- a/src/__test__/app.test.ts
+++ b/src/__test__/app.test.ts
@@ -10,6 +10,7 @@ import {
   instruction as instructionFactory,
 } from '~/app.js';
 import { GammaMarketApiClient } from '~/gamma/market/market.js';
+import { createServices, createTransactionRunner } from '~/services/index.js';
 import type { Storage } from '~/storage/index.js';
 
 const storage = td.object<Storage>();
@@ -21,7 +22,15 @@ let instruction: AppInstruction<string>;
 
 beforeEach(() => {
   td.reset();
-  app = initializeApp({ storage, logger, gammaApiClient });
+  const services = createServices(storage, gammaApiClient);
+  const withTransaction = createTransactionRunner(storage, gammaApiClient);
+  app = initializeApp({
+    storage,
+    logger,
+    gammaApiClient,
+    services,
+    withTransaction,
+  });
   instruction = td.function<AppInstruction<string>>();
 });
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -7,6 +7,11 @@ import {
   createGammaMarketApiClient,
   GammaMarketApiClient,
 } from './gamma/market/market.js';
+import {
+  createServices,
+  createTransactionRunner,
+  type Services,
+} from './services/index.js';
 import { createStorage, type Storage } from './storage/index.js';
 import { AppConfig, readConfig } from './utils/config.js';
 import { createLogger } from './utils/logger.js';
@@ -31,6 +36,10 @@ type AppState = {
 
 export type AppDependencies = {
   storage: Storage;
+  services: Services;
+  withTransaction: <T>(
+    callback: (services: Services) => Promise<T>,
+  ) => Promise<T>;
   logger: Logger;
   gammaApiClient: GammaMarketApiClient;
 };
@@ -185,8 +194,12 @@ export const initializeAppWithConfig = async ({
   const storage = await createStorage(DATABASE_URL);
   //GAMMA API client
   const gammaApiClient = createGammaMarketApiClient({ logger });
+  const services = createServices(storage, gammaApiClient);
+  const withTransaction = createTransactionRunner(storage, gammaApiClient);
   return initializeApp({
     storage,
+    services,
+    withTransaction,
     logger,
     gammaApiClient,
   });

--- a/src/cli/__test__/market.test.ts
+++ b/src/cli/__test__/market.test.ts
@@ -10,6 +10,7 @@ import type {
   GammaMarket,
   GammaMarketApiClient,
 } from '~/gamma/market/market.js';
+import { createServices, createTransactionRunner } from '~/services/index.js';
 import type { Storage } from '~/storage/index.js';
 import type { MarketStorage } from '~/storage/market.js';
 
@@ -55,7 +56,15 @@ let app: App;
 describe('markets command', () => {
   beforeEach(() => {
     td.reset();
-    app = initializeApp({ storage, logger, gammaApiClient });
+    const services = createServices(storage, gammaApiClient);
+    const withTransaction = createTransactionRunner(storage, gammaApiClient);
+    app = initializeApp({
+      storage,
+      logger,
+      gammaApiClient,
+      services,
+      withTransaction,
+    });
   });
 
   const configureCommandTree = (command: Command) => {

--- a/src/cli/__test__/market.test.ts
+++ b/src/cli/__test__/market.test.ts
@@ -172,6 +172,26 @@ describe('markets command', () => {
       logger.info({ result: testMarket }, 'Market imported successfully'),
     );
   });
+  it('should throw when a malformed market is returned from Gamma', async () => {
+    td.when(gammaApiClient.getMarketById(td.matchers.isA(String))).thenResolve({
+      id: 1,
+      conditionId: 'condition-123',
+      question: 'Will this command work?',
+      category: 'Politics',
+      description: null,
+      outcomes: 'not-a-valid-json',
+      endDate: '2026-04-10T12:00:00.000Z',
+      volume: '1234.56',
+      active: true,
+      closed: false,
+    } as unknown as any);
+
+    await expect(
+      createCommandUnderTest().parseAsync(['import', 'condition-123'], {
+        from: 'user',
+      }),
+    ).rejects.toThrow('Unexpected token');
+  });
 
   it('fails when Gamma does not return the market to import', async () => {
     td.when(gammaApiClient.getMarketById('missing-market')).thenResolve(null);

--- a/src/cli/__test__/wallet.test.ts
+++ b/src/cli/__test__/wallet.test.ts
@@ -30,7 +30,13 @@ describe('wallet command', () => {
     td.reset();
     const services = createServices(storage, gammaApiClient);
     const withTransaction = createTransactionRunner(storage, gammaApiClient);
-    app = initializeApp({ storage, logger, gammaApiClient, services, withTransaction });
+    app = initializeApp({
+      storage,
+      logger,
+      gammaApiClient,
+      services,
+      withTransaction,
+    });
   });
 
   const configureCommandTree = (command: Command) => {

--- a/src/cli/__test__/wallet.test.ts
+++ b/src/cli/__test__/wallet.test.ts
@@ -7,6 +7,7 @@ import { beforeEach, describe, expect, it } from 'vitest';
 import { App, initializeApp } from '~/app.js';
 import { wallet } from '~/cli/commands/wallet.js';
 import { GammaMarketApiClient } from '~/gamma/market/market.js';
+import { createServices, createTransactionRunner } from '~/services/index.js';
 import type { Storage } from '~/storage/index.js';
 import type { WalletStorage } from '~/storage/wallet.js';
 
@@ -27,7 +28,9 @@ let app: App;
 describe('wallet command', () => {
   beforeEach(() => {
     td.reset();
-    app = initializeApp({ storage, logger, gammaApiClient });
+    const services = createServices(storage, gammaApiClient);
+    const withTransaction = createTransactionRunner(storage, gammaApiClient);
+    app = initializeApp({ storage, logger, gammaApiClient, services, withTransaction });
   });
 
   const configureCommandTree = (command: Command) => {

--- a/src/cli/commands/market.ts
+++ b/src/cli/commands/market.ts
@@ -2,8 +2,6 @@ import { createCommand, createOption } from 'commander';
 import { z } from 'zod';
 
 import { App, instruction } from '~/app.js';
-import type { GammaMarket } from '~/gamma/market/market.js';
-import type { CreateMarketInput } from '~/storage/market.js';
 import { Models } from '~/storage/models.js';
 
 const listMarketSchema = z.object({
@@ -15,34 +13,6 @@ const listMarketSchema = z.object({
 const listMarketsByCategorySchema = listMarketSchema.extend({
   category: Models.Category,
 });
-const marketOutcomesSchema = z.tuple([z.string(), z.string()]);
-
-function parseMarketOutcomes(outcomes: string) {
-  const parsedJson = JSON.parse(outcomes);
-  const parsedOutcomes = marketOutcomesSchema.parse(parsedJson);
-
-  return {
-    outcome_a: parsedOutcomes[0],
-    outcome_b: parsedOutcomes[1],
-  };
-}
-
-function mapGammaMarketToCreateMarketInput(market: GammaMarket) {
-  const { outcome_a, outcome_b } = parseMarketOutcomes(market.outcomes);
-
-  return {
-    condition_id: market.conditionId,
-    question: market.question,
-    category: null,
-    outcome_a,
-    outcome_b,
-    status: market.closed ? 'CLOSED' : market.active ? 'ACTIVE' : 'CLOSED',
-    outcome: null,
-    closes_at: new Date(market.endDate),
-    resolved_at: null,
-    volume_usd: market.volume,
-  } satisfies CreateMarketInput;
-}
 
 const listMarketsByCategory = (app: App) =>
   createCommand('list-markets-by-category')
@@ -139,20 +109,8 @@ const importMarket = (app: App) =>
     .argument('<conditionId>', 'Market condition ID')
     .action(async (conditionId: string) => {
       const result = await app
-        .execute(({ gammaApiClient, storage }) =>
-          instruction(async () => {
-            const market = await gammaApiClient.getMarketById(conditionId);
-
-            if (!market) {
-              throw new Error(
-                `Market with condition ID "${conditionId}" was not found in Gamma`,
-              );
-            }
-
-            return storage.market.upsertMarket(
-              mapGammaMarketToCreateMarketInput(market),
-            );
-          }),
+        .execute(({ services }) =>
+          instruction(() => services.market.importMarket(conditionId)),
         )
         .once();
 

--- a/src/cli/commands/market.ts
+++ b/src/cli/commands/market.ts
@@ -2,8 +2,6 @@ import { createCommand, createOption } from 'commander';
 import { z } from 'zod';
 
 import { App, instruction } from '~/app.js';
-import type { GammaMarket } from '~/gamma/market/market.js';
-import type { CreateMarketInput } from '~/storage/market.js';
 import { Models } from '~/storage/models.js';
 
 const listMarketSchema = z.object({
@@ -15,34 +13,6 @@ const listMarketSchema = z.object({
 const listMarketsByCategorySchema = listMarketSchema.extend({
   category: Models.Category,
 });
-const marketOutcomesSchema = z.tuple([z.string(), z.string()]);
-
-function parseMarketOutcomes(outcomes: string) {
-  const parsedJson = JSON.parse(outcomes);
-  const parsedOutcomes = marketOutcomesSchema.parse(parsedJson);
-
-  return {
-    outcome_a: parsedOutcomes[0],
-    outcome_b: parsedOutcomes[1],
-  };
-}
-
-function mapGammaMarketToCreateMarketInput(market: GammaMarket) {
-  const { outcome_a, outcome_b } = parseMarketOutcomes(market.outcomes);
-
-  return {
-    condition_id: market.conditionId,
-    question: market.question,
-    category: null,
-    outcome_a,
-    outcome_b,
-    status: market.closed ? 'CLOSED' : market.active ? 'ACTIVE' : 'CLOSED',
-    outcome: null,
-    closes_at: new Date(market.endDate),
-    resolved_at: null,
-    volume_usd: market.volume,
-  } satisfies CreateMarketInput;
-}
 
 const listMarketsByCategory = (app: App) =>
   createCommand('list-markets-by-category')
@@ -143,20 +113,8 @@ const importMarket = (app: App) =>
     .argument('<conditionId>', 'Market condition ID')
     .action(async (conditionId: string) => {
       const result = await app
-        .execute(({ gammaApiClient, storage }) =>
-          instruction(async () => {
-            const market = await gammaApiClient.getMarketById(conditionId);
-
-            if (!market) {
-              throw new Error(
-                `Market with condition ID "${conditionId}" was not found in Gamma`,
-              );
-            }
-
-            return storage.market.upsertMarket(
-              mapGammaMarketToCreateMarketInput(market),
-            );
-          }),
+        .execute(({ services }) =>
+          instruction(() => services.market.importMarket(conditionId)),
         )
         .once();
 

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,0 +1,26 @@
+import { createMarketService, type MarketService } from './market.js';
+import type { GammaMarketApiClient } from '~/gamma/market/market.js';
+import type { Repo, Storage } from '~/storage/index.js';
+
+export type Services = {
+  market: MarketService;
+};
+
+export function createServices(
+  repo: Repo,
+  gammaApiClient: GammaMarketApiClient,
+): Services {
+  return {
+    market: createMarketService(repo, gammaApiClient),
+  };
+}
+
+export function createTransactionRunner(
+  storage: Storage,
+  gammaApiClient: GammaMarketApiClient,
+) {
+  return <T>(callback: (services: Services) => Promise<T>) =>
+    storage.transaction((repo) =>
+      callback(createServices(repo, gammaApiClient)),
+    );
+}

--- a/src/services/market.ts
+++ b/src/services/market.ts
@@ -1,0 +1,51 @@
+import type {
+  GammaMarket,
+  GammaMarketApiClient,
+} from '~/gamma/market/market.js';
+import type { Repo } from '~/storage/index.js';
+import type { CreateMarketInput } from '~/storage/market.js';
+import type { Models } from '~/storage/models.js';
+
+export type MarketService = {
+  importMarket: (conditionId: string) => Promise<Models['Market']>;
+};
+
+function mapGammaMarketToCreateMarketInput(
+  market: GammaMarket,
+): CreateMarketInput {
+  const outcomes: [string, string] = JSON.parse(market.outcomes);
+
+  return {
+    condition_id: market.conditionId,
+    question: market.question,
+    category: null,
+    outcome_a: outcomes[0],
+    outcome_b: outcomes[1],
+    status: market.closed ? 'CLOSED' : market.active ? 'ACTIVE' : 'CLOSED',
+    outcome: null,
+    closes_at: new Date(market.endDate),
+    resolved_at: null,
+    volume_usd: market.volume,
+  };
+}
+
+export function createMarketService(
+  repo: Repo,
+  gammaApiClient: GammaMarketApiClient,
+): MarketService {
+  return {
+    importMarket: async (conditionId) => {
+      const market = await gammaApiClient.getMarketById(conditionId);
+
+      if (!market) {
+        throw new Error(
+          `Market with condition ID "${conditionId}" was not found in Gamma`,
+        );
+      }
+
+      return repo.market.upsertMarket(
+        mapGammaMarketToCreateMarketInput(market),
+      );
+    },
+  };
+}

--- a/src/services/market.ts
+++ b/src/services/market.ts
@@ -21,7 +21,7 @@ function mapGammaMarketToCreateMarketInput(
     category: null,
     outcome_a: outcomes[0],
     outcome_b: outcomes[1],
-    status: market.closed ? 'CLOSED' : market.active ? 'ACTIVE' : 'CLOSED',
+    status: market.active && !market.closed ? 'ACTIVE' : 'CLOSED',
     outcome: null,
     closes_at: new Date(market.endDate),
     resolved_at: null,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,5 +9,6 @@ export default defineConfig({
   },
   test: {
     globals: true,
+    include: ['src/**/*.test.ts'],
   },
 });


### PR DESCRIPTION
added tx runner helper to get cross-service tx capability without needing to manually insantiate services in the higher level coordinator each time.
Refactored import-market cli to use an example service. Updated vitest config to only run TS test files, not ones in dist.